### PR TITLE
feat: Update site identity to Mac Pro Hub and add Location Services stub

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1891,6 +1891,130 @@ footer p {
     margin-bottom: 1rem;
 }
 
+/* Mac Pro Location Services Section Styles */
+.map-search-layout {
+    display: grid;
+    grid-template-columns: 300px 1fr; /* Controls on left, map on right */
+    gap: 1.5rem;
+    align-items: flex-start; /* Align items to the top of their grid area */
+    margin-top: 1.5rem;
+}
+
+.map-controls-area {
+    /* Uses .content-section-panel styles, specific overrides can go here if needed */
+}
+
+.map-placeholder {
+    position: relative;
+    width: 100%;
+    min-height: 450px;
+    background-color: #e9e9ed; /* Light gray, similar to other placeholders */
+    border-radius: 8px;
+    border: 1px solid #d0d0d0; /* Slightly darker border for map area */
+    overflow: hidden; /* Important for keeping pins and tooltips contained if they go near edge */
+    background-image: url('https://via.placeholder.com/1000x700/e9e9ed/cccccc?Text=Area+Map+Showing+Mac+Pro+Locations');
+    background-size: cover;
+    background-position: center;
+}
+
+.map-pin {
+    position: absolute;
+    transform: translate(-50%, -100%); /* Center horizontally, anchor bottom point */
+    width: auto; /* Auto width based on content */
+    height: auto;
+    padding: 6px 10px; /* Slightly more padding for pill */
+    border-radius: 20px; /* Pill shape */
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 3px 6px rgba(0,0,0,0.25);
+    cursor: pointer;
+    transition: transform 0.2s ease-out, background-color 0.2s ease-out, box-shadow 0.2s ease-out;
+    font-weight: 500;
+    font-size: 0.9rem; /* Pin text size */
+}
+
+.pin-icon-map {
+    font-size: 1.1rem; /* Adjusted for typical emoji/icon size */
+    margin-right: 6px; /* Space between icon and text if any */
+    line-height: 1; /* Ensure icon aligns well */
+    display: inline-block;
+}
+
+.macpro-store-pin {
+    background-color: #0071e3; /* Apple blue */
+}
+.macpro-store-pin .pin-icon-map {
+    /* Specific icon styles if needed, e.g. Apple logo color if not an emoji */
+}
+
+.macpro-service-pin {
+    background-color: #f5a623; /* Orange/Gold for service centers */
+    border-radius: 8px; /* More squared shape for service pins */
+    padding: 7px 9px; /* Slightly adjusted padding for square look */
+}
+.macpro-service-pin .pin-icon-map {
+    /* Specific icon styles if needed */
+}
+
+.map-pin:hover {
+    transform: translate(-50%, -105%) scale(1.1); /* Lift slightly more and scale up */
+    box-shadow: 0 5px 10px rgba(0,0,0,0.3);
+    z-index: 10; /* Ensure hovered pin is above others */
+}
+
+.map-pin-tooltip {
+    position: absolute;
+    background-color: rgba(28, 28, 30, 0.9); /* Dark, semi-transparent Apple style */
+    color: white;
+    padding: 6px 12px;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    white-space: nowrap; /* Prevent tooltip text from wrapping */
+    transform: translate(-50%, -15px); /* Position above the pin tip */
+    /* bottom: 100%;  Alternative positioning, needs pin to be non-100% transform for y */
+    /* left: 50%; */
+    z-index: 20; /* Above pins */
+    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+    pointer-events: none; /* Tooltip itself shouldn't be interactive */
+    opacity: 0; /* Hidden by default */
+    transition: opacity 0.2s ease-in-out;
+    /* Example of making one visible for demo - remove for actual use */
+    /* opacity: 1; */
+}
+
+/* Show tooltip on hover (JS might be better for click or more complex interactions) */
+.map-pin:hover .map-pin-tooltip { /* This would require tooltip to be child of pin */
+    opacity: 1;
+}
+/* If tooltip is not a child, JS would handle adding an 'active' class or similar */
+/* Example: .map-pin-tooltip.active { opacity: 1; } */
+
+
+/* Responsive adjustments for Location Services section */
+@media (max-width: 992px) {
+    .map-search-layout {
+        grid-template-columns: 1fr; /* Stack controls above map */
+    }
+    .map-controls-area {
+        margin-bottom: 1.5rem; /* Add space between controls and map when stacked */
+    }
+}
+
+@media (max-width: 768px) {
+    .map-placeholder {
+        min-height: 350px; /* Reduce map height on smaller screens */
+    }
+    .map-pin {
+        padding: 5px 8px;
+        font-size: 0.85rem;
+    }
+    .pin-icon-map {
+        font-size: 1rem;
+    }
+}
+
 .stat-item {
     margin-bottom: 1rem;
     display: flex;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Advanced Feature Showcase - Project Nautilus</title>
+    <title>Mac Pro Hub - Power. Redefined.</title>
     <meta name="description" content="A demonstration website showcasing a wide array of advanced web features and a dynamic, themeable user interface.">
     <link rel="icon" href="/favicon.ico" sizes="any">
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
@@ -16,7 +16,7 @@
     <header role="banner">
         <div class="container">
             <!-- Logo: ensure it's properly described if it were an image -->
-            <h1 class="logo" tabindex="0">Dennis Doubin</h1> <!-- Made focusable if it acts like a home link -->
+            <h1 class="logo" tabindex="0">Mac Pro Hub</h1> <!-- Made focusable if it acts like a home link -->
             <nav role="navigation" aria-label="Main Navigation">
                 <ul>
                     <li><a href="#home">Home</a></li>
@@ -129,19 +129,19 @@
                     <path id="svgPath3" d="M50 150 Q100 120 150 150 T250 150" stroke="url(#svgGrad)" stroke-width="2" fill="none" opacity="0.4"/>
                 </svg>
                 <h2 id="hero-title">Welcome</h2>
-                <p>Experience the dynamic artistry of Dennis Doubin, a conductor renowned for his passionate interpretations, profound musical insight, and an electrifying stage presence that captivates audiences worldwide.</p>
+                <p>Experience dynamic artistry, passionate interpretations, profound musical insight, and an electrifying stage presence that captivates audiences worldwide.</p>
                 <div class="hero-image-placeholder"><span>[Hero Image Placeholder]</span></div>
             </section>
 
-            Biography Section
+            <!-- Biography Section (Original content removed/genericized) -->
             <section id="biography" class="content-section" role="region" aria-labelledby="bio-title">
-                <h2 id="bio-title">Biography</h2>
-                <p>Born in Prague in 1965, Dennis Doubin's prodigious musical talent was unmistakable from a young age. It was his grandfather, a former cellist with the Czech Philharmonic, who first placed a miniature baton in his hand, igniting a lifelong passion. Early studies at the Prague Conservatory under the tutelage of the legendary Maestro Vasek Novak (a fictional mentor) honed his innate understanding of orchestral color and rhythmic vitality.</p>
-                <p>A recipient of the prestigious 'Golden Lion Scholarship' (fictional award), Doubin furthered his studies at The Juilliard School in New York. There, he absorbed wisdom from iconic figures and visiting masters, graduating with top honors and a reputation for fiery intellect and profound musicality. His conducting is a mesmerizing blend of intellectual rigor and raw emotional power; he seeks to illuminate the architectural grandeur of each score while fostering a collaborative spirit that allows musicians the freedom to bring their own voices to the fore.</p>
-                <p>"Music," Dennis Doubin often says, "is the ultimate dialogue – between composer and performer, performer and audience, soul and the universe. Our role is to be faithful interpreters and passionate communicators of these timeless human stories."</p>
+                <h2 id="bio-title">About Us</h2>
+                <p>Born from a passion for performance and artistry, this project showcases dedication to musical excellence. Early studies and tutelage under legendary mentors honed an innate understanding of orchestral color and rhythmic vitality.</p>
+                <p>A recipient of prestigious awards, further studies at renowned institutions absorbed wisdom from iconic figures, graduating with top honors and a reputation for fiery intellect and profound musicality. The approach is a mesmerizing blend of intellectual rigor and raw emotional power; seeking to illuminate the architectural grandeur of each score while fostering a collaborative spirit.</p>
+                <p>"Music," it is often said, "is the ultimate dialogue – between composer and performer, performer and audience, soul and the universe. Our role is to be faithful interpreters and passionate communicators of these timeless human stories."</p>
                 <div class="review-quotes">
                     <p class="quote">"A force of nature on the podium." - <span>New York Classical Review (Fictional)</span></p>
-                    <p class="quote">"Doubin doesn't just conduct the music; he lives it, breathes it, and makes it overwhelmingly present." - <span>The Guardian (Fictional attribution)</span></p>
+                    <p class="quote">"The music is lived, breathed, and made overwhelmingly present." - <span>The Guardian (Fictional attribution)</span></p>
                 </div>
                 <h3 class="timeline-title">Career Milestones</h3>
                 <div class="timeline">
@@ -188,44 +188,44 @@
                 </div>
             </section>
 
-            Performances Section
+            <!-- Performances Section (Original content removed/genericized) -->
             <section id="performances" class="content-section" role="region" aria-labelledby="perf-title">
-                <h2 id="perf-title">Performances</h2>
-                <h3>Upcoming Performances</h3>
+                <h2 id="perf-title">Events</h2>
+                <h3>Upcoming Events</h3>
                 <ul>
-                    <li><strong>Mahler's Symphony No. 5:</strong> January 15, 2024, Carnegie Hall, New York with the New York Philharmonic. <a href="#">A monumental journey through shadow and light, Maestro Doubin leads a transcendent performance of Mahler's epic Fifth Symphony. Presented by the New York Arts Foundation.</a></li>
-                    <li><strong>An Evening with Beethoven:</strong> February 22, 2024, Barbican Centre, London with the London Symphony Orchestra, feat. Mitsuko Uchida, piano. <a href="#">Experience the timeless genius of Beethoven, including the majestic 'Emperor' Piano Concerto No. 5. A study in heroic struggle and ultimate triumph.</a></li>
+                    <li><strong>Event Title 1:</strong> January 15, 2024, Venue Name, City with Guest Artist. <a href="#">A monumental journey through shadow and light, this event leads a transcendent performance. Presented by the Arts Foundation.</a></li>
+                    <li><strong>Event Title 2:</strong> February 22, 2024, Venue Name, City with Guest Artist. <a href="#">Experience timeless genius, including a majestic concerto. A study in heroic struggle and ultimate triumph.</a></li>
                 </ul>
-                <h3>Past Performances</h3>
+                <h3>Past Events</h3>
                 <ul>
                     <li><strong>Stravinsky's Rite of Spring:</strong> October 5, 2023, Philharmonie de Paris, with Orchestre de Paris. A groundbreaking rendition praised for its primal energy and clarity.</li>
                     <li><strong>Brahms Cycle Part I:</strong> June 12, 2023, Musikverein, Vienna with the Vienna Philharmonic. The commencement of a celebrated Brahms symphony cycle.</li>
                 </ul>
             </section>
 
-            Media Section
+            <!-- Media Section (Original content removed/genericized) -->
             <section id="media" class="content-section" role="region" aria-labelledby="media-title">
-                <h2 id="media-title">Media</h2>
-                <p>Explore photos and videos of Dennis Doubin in action.</p>
+                <h2 id="media-title">Media Showcase</h2>
+                <p>Explore photos and videos of our projects and events.</p>
                 <div class="media-showcase">
                     <h3>Photo Gallery</h3>
 
-                    <div class="swiper advanced-carousel" role="region" aria-roledescription="carousel" aria-label="Photo Gallery of Dennis Doubin">
+                    <div class="swiper advanced-carousel" role="region" aria-roledescription="carousel" aria-label="Photo Gallery of Projects and Events">
                         <div class="swiper-wrapper">
                             <div class="swiper-slide">
-                                <img src="https://via.placeholder.com/800x450/2a2a2a/FFFFFF?Text=Vienna+Philharmonic+Dynamic+Gestures+Mid-Crescendo+Stage-Lit+Lens+Flare+Concert+Photography" alt="Dennis Doubin conducting the Vienna Philharmonic with dynamic, fluid gestures, caught mid-crescendo. View from slightly below, capturing the energy of the orchestra and the grandeur of a historic concert hall. Lighting is warm, stage-lit, with a slight lens flare. Style: High-impact concert photography.">
-                                <div class="swiper-caption">Conducting the Vienna Philharmonic, 2023.</div>
+                                <img src="https://via.placeholder.com/800x450/2a2a2a/FFFFFF?Text=Vienna+Philharmonic+Dynamic+Gestures+Mid-Crescendo+Stage-Lit+Lens+Flare+Concert+Photography" alt="Conducting performance with dynamic, fluid gestures, caught mid-crescendo. View from slightly below, capturing the energy and the grandeur of a historic concert hall. Lighting is warm, stage-lit, with a slight lens flare. Style: High-impact concert photography.">
+                                <div class="swiper-caption">Performance at a historic venue, 2023.</div>
                             </div>
                             <div class="swiper-slide">
-                                <img src="https://via.placeholder.com/800x450/3a3a3a/FFFFFF?Text=Rehearsal+Close-up+Expressive+Hands+Sheet+Music+Soft+Window+Light+Photojournalistic" alt="Dennis Doubin in intense rehearsal with a focused orchestra. Close-up on Doubin's expressive face and hands, sheet music visible. Natural, soft window light from the side, creating depth. Atmosphere of deep concentration and collaboration. Style: Candid, photojournalistic.">
+                                <img src="https://via.placeholder.com/800x450/3a3a3a/FFFFFF?Text=Rehearsal+Close-up+Expressive+Hands+Sheet+Music+Soft+Window+Light+Photojournalistic" alt="Intense rehearsal with a focused team. Close-up on expressive face and hands, documents visible. Natural, soft window light from the side, creating depth. Atmosphere of deep concentration and collaboration. Style: Candid, photojournalistic.">
                                 <div class="swiper-caption">Rehearsal for the Summer Festival.</div>
                             </div>
                             <div class="swiper-slide">
-                                <img src="https://via.placeholder.com/800x450/4a4a4a/FFFFFF?Text=Carnegie+Hall+Ovation+Hand+on+Heart+Golden+Lighting+Iconic+Performance+Moment" alt="Dennis Doubin acknowledging a roaring ovation at Carnegie Hall, slight smile, hand to heart. View from the audience, capturing the vastness of the hall and the warmth of the reception. Golden lighting, sense of triumph. Style: Iconic performance moment.">
-                                <div class="swiper-caption">Post-concert ovation at Carnegie Hall.</div>
+                                <img src="https://via.placeholder.com/800x450/4a4a4a/FFFFFF?Text=Carnegie+Hall+Ovation+Hand+on+Heart+Golden+Lighting+Iconic+Performance+Moment" alt="Acknowledging a roaring ovation at a grand hall, slight smile, hand to heart. View from the audience, capturing the vastness of the hall and the warmth of the reception. Golden lighting, sense of triumph. Style: Iconic performance moment.">
+                                <div class="swiper-caption">Post-event ovation at a grand hall.</div>
                             </div>
                             <div class="swiper-slide">
-                                <img src="https://via.placeholder.com/800x450/2d2d2d/FFFFFF?Text=Studio+Portrait+Authoritative+Presence+Minimalist+Setting+Clean+Lighting+Contemporary" alt="Studio portrait of Dennis Doubin, looking directly at the camera with a calm, authoritative presence. Modern, minimalist setting. Lighting is clean and even, emphasizing a sharp, tailored suit. Style: Contemporary corporate/artistic portrait.">
+                                <img src="https://via.placeholder.com/800x450/2d2d2d/FFFFFF?Text=Studio+Portrait+Authoritative+Presence+Minimalist+Setting+Clean+Lighting+Contemporary" alt="Studio portrait, looking directly at the camera with a calm, authoritative presence. Modern, minimalist setting. Lighting is clean and even, emphasizing a sharp, tailored suit. Style: Contemporary corporate/artistic portrait.">
                                 <div class="swiper-caption">Studio Portrait, 2024.</div>
                             </div>
                         </div>
@@ -256,8 +256,8 @@
                                 <p>Excerpt: Brahms Symphony No. 1</p>
                             </div>
                             <div class="video-player-placeholder">
-                                <img src="https://via.placeholder.com/400x225/222/FFFFFF?Text=Thumb:Interview+Doubin+Thoughtful+Cinematic+Study+Background" alt="Video Thumbnail: Dennis Doubin in a thoughtful interview setting, subtly lit, looking off-camera as if in deep conversation. Background is a library or study. Style: Cinematic interview still.">
-                                <div class="play-button-overlay" role="button" tabindex="0" aria-label="Play video: Interview: The Role of a Conductor">▶</div>
+                                <img src="https://via.placeholder.com/400x225/222/FFFFFF?Text=Thumb:Interview+Thoughtful+Cinematic+Study+Background" alt="Video Thumbnail: Person in a thoughtful interview setting, subtly lit, looking off-camera as if in deep conversation. Background is a library or study. Style: Cinematic interview still.">
+                                <div class="play-button-overlay" role="button" tabindex="0" aria-label="Play video: Interview: The Role of Leadership">▶</div>
                                 <div class="fake-controls">
                                     <span class="control-icon play-pause-icon">❚❚</span>
                                     <div class="fake-progress-bar-container"><div class="fake-progress-bar-filled" style="width: 60%;"></div></div>
@@ -266,12 +266,12 @@
                                     <span class="control-icon settings-icon">⚙</span>
                                     <span class="control-icon fullscreen-icon">⛶</span>
                                 </div>
-                                <p>Interview: The Role of a Conductor</p>
+                                <p>Interview: The Role of Leadership</p>
                             </div>
 
                             <div class="video-player-placeholder">
-                                <img src="https://via.placeholder.com/400x225/222/FFFFFF?Text=Thumb:Salzburg+Festival+Live+Performance+Energetic+Stage+Lights" alt="Video Thumbnail: A dynamic shot from a live performance at the Salzburg Festival, capturing the energy of the orchestra under bright stage lights. Style: Energetic live event still.">
-                                <div class="play-button-overlay" role="button" tabindex="0" aria-label="Play video: Live from Salzburg Festival">▶</div>
+                                <img src="https://via.placeholder.com/400x225/222/FFFFFF?Text=Thumb:Major+Festival+Live+Performance+Energetic+Stage+Lights" alt="Video Thumbnail: A dynamic shot from a live performance at a major festival, capturing the energy under bright stage lights. Style: Energetic live event still.">
+                                <div class="play-button-overlay" role="button" tabindex="0" aria-label="Play video: Live from Major Festival">▶</div>
                                 <div class="fake-controls">
                                     <span class="control-icon play-pause-icon">❚❚</span>
                                     <div class="fake-progress-bar-container"><div class="fake-progress-bar-filled" style="width: 20%;"></div></div>
@@ -280,10 +280,10 @@
                                     <span class="control-icon settings-icon">⚙</span>
                                     <span class="control-icon fullscreen-icon">⛶</span>
                                 </div>
-                                <p>Live from Salzburg Festival</p>
+                                <p>Live from Major Festival</p>
                             </div>
                             <div class="video-player-placeholder">
-                                <img src="https://via.placeholder.com/400x225/222/FFFFFF?Text=Thumb:Behind+Scenes+Rehearsal+Candid+Laughter+Documentary" alt="Video Thumbnail: Behind-the-scenes glimpse of Dennis Doubin in rehearsal, laughing with musicians. Casual, warm, and human moment. Style: Documentary, candid.">
+                                <img src="https://via.placeholder.com/400x225/222/FFFFFF?Text=Thumb:Behind+Scenes+Rehearsal+Candid+Laughter+Documentary" alt="Video Thumbnail: Behind-the-scenes glimpse of a team in rehearsal, laughing together. Casual, warm, and human moment. Style: Documentary, candid.">
                                 <div class="play-button-overlay" role="button" tabindex="0" aria-label="Play video: A Day in Rehearsal">▶</div>
                                 <div class="fake-controls">
                                     <span class="control-icon play-pause-icon">❚❚</span>
@@ -300,13 +300,13 @@
                 </div>
             </section>
 
-            Legacy Dataviz Section
+            <!-- Legacy Dataviz Section (Original content removed/genericized) -->
             <section id="legacy-dataviz" class="content-section" role="region" aria-labelledby="dataviz-title">
                 <div class="container">
-                    <h2 id="dataviz-title">A Legacy in Motion</h2>
-                    <p class="viz-description">An abstract representation of Maestro Doubin's journey through landmark achievements and pivotal collaborations over the decades.</p>
+                    <h2 id="dataviz-title">Our Journey in Motion</h2>
+                    <p class="viz-description">An abstract representation of our journey through landmark achievements and pivotal collaborations over the decades.</p>
                     <div class="dataviz-canvas-container">
-                        <canvas id="dataviz-canvas" role="img" aria-label="Abstract 3D network graph visualizing Dennis Doubin's career milestones, connections between years, events, and orchestras, animated to show growth and evolution."></canvas>
+                        <canvas id="dataviz-canvas" role="img" aria-label="Abstract 3D network graph visualizing career milestones, connections between years, events, and collaborations, animated to show growth and evolution."></canvas>
                     </div>
                 </div>
             </section>
@@ -793,12 +793,42 @@
                         <p id="upload-feedback"></p>
                     </div>
                 </section>
+
+                <section id="macpro-location-services-section" class="content-section feature-section">
+                    <h2>Find Mac Pro Support & Retail</h2>
+                    <p class="section-description">Locate Apple Stores and Authorized Service Centers for Mac Pro sales, support, and expert advice.</p>
+                    <div class="map-search-layout">
+                        <div class="map-controls-area content-section-panel">
+                            <h4>Search Locations</h4>
+                            <div class="form-group">
+                                <label for="macpro-location-search-input">Enter City, Zip Code, or Address</label>
+                                <input type="text" id="macpro-location-search-input" placeholder="e.g., Cupertino, CA or 1 Infinite Loop">
+                            </div>
+                            <div class="form-group">
+                                <label for="macpro-location-type-filter">Show</label>
+                                <select id="macpro-location-type-filter">
+                                    <option value="all">All Locations</option>
+                                    <option value="store">Apple Store (Sales & Support)</option>
+                                    <option value="service">Authorized Service Center (Mac Pro Specialists)</option>
+                                </select>
+                            </div>
+                            <button type="button" class="btn btn-primary">Find Locations</button>
+                        </div>
+                        <div id="macpro-map-placeholder-container" class="map-placeholder">
+                            <!-- Mock map pins -->
+                            <div class="map-pin macpro-store-pin" style="top: 30%; left: 40%;" title="Apple Store - Infinite Loop (Mac Pro Available)"><span class="pin-icon-map"></span></div>
+                            <div class="map-pin macpro-service-pin" style="top: 50%; left: 60%;" title="Mac Pro Authorized Service - Tech Solutions"><span class="pin-icon-map">🛠️</span></div>
+                            <div class="map-pin macpro-store-pin" style="top: 65%; left: 30%;" title="Apple Store - Valley Fair (Mac Pro Experts)"><span class="pin-icon-map"></span></div>
+                            <div class="map-pin-tooltip" style="top: 25%; left: 42%;">Apple Store - Infinite Loop</div> <!-- Example Tooltip -->
+                        </div>
+                    </div>
+                </section>
             </div>
             <!-- End New Feature Sections -->
 
             <footer>
                 <div class="container">
-                    <p>&copy; 2024 Dennis Doubin. All Rights Reserved.</p>
+                    <p>&copy; 2024 Mac Pro Hub. All Rights Reserved. (Fan Showcase)</p>
             <div class="footer-links">
                 <a href="#">Privacy Policy</a> | <a href="#">Terms of Use</a> | <a href="#contact">Contact</a>
             </div>


### PR DESCRIPTION
This commit includes two main updates:

1.  **Site Identity Update:**
    *   All references to the previous placeholder identity ("Dennis Doubin") have been removed from HTML and JS files.
    *   The website `<title>` has been changed to "Mac Pro Hub - Power. Redefined.".
    *   The header logo/site title text has been updated to "Mac Pro Hub".
    *   The footer copyright notice has been updated to "© 2024 Mac Pro Hub. All Rights Reserved. (Fan Showcase)".

2.  **Location Services (Map Placeholder) Feature Stub:**
    *   Added a new section: "Find Mac Pro Support & Retail".
    *   This section features a two-column layout with:
        *   A controls area for searching/filtering locations (input for city/zip, select for location type).
        *   A large map placeholder styled with a background image and mock map pins.
        *   Pins are styled differently for "Apple Stores" (Apple blue, pill shape) and "Authorized Service Centers" (orange/gold, different shape).
        *   An example tooltip for a map pin is included.
    *   The section is responsive and styled according to the Mac Pro theme.

This commit addresses the first two steps of the planned Phase 4. Remaining Phase 4 items (further feature stubs, Mac Pro history structure, UI polish) are pending.